### PR TITLE
Add ollama support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(npm run lint)",
       "WebFetch(domain:vercel.com)",
       "WebFetch(domain:sdk.vercel.ai)",
-      "WebFetch(domain:ai-sdk.dev)"
+      "WebFetch(domain:ai-sdk.dev)",
+      "Bash(npm run compile:*)"
     ],
     "deny": []
   }

--- a/src/services/customOllamaFetch.ts
+++ b/src/services/customOllamaFetch.ts
@@ -1,0 +1,250 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+const execAsync = promisify(exec);
+
+export async function getInstalledModelsAsync(): Promise<string[]> {
+    const { stdout } = await execAsync('ollama list');
+    const lines = stdout.trim().split('\n');
+    return lines.slice(1).map((l) => l.trim().split(/\s+/)[0]);
+}
+
+/**
+ * Helper that turns an async iterator over data (the stream that
+ * Ollama emits) into a ReadableStream that the SDK can consume.
+ */
+function ollamaStreamToSdkStream(ollamaBody: ReadableStream<any>): ReadableStream<any> {
+  const reader = ollamaBody.getReader();
+
+  // The SDK will consume the stream as a readable byte stream.
+  // We'll push a new line‑delimited JSON chunk for every piece of
+  // text that Ollama sends.
+  const pull = async (controller: ReadableStreamDefaultController) => {
+    const { done, value } = await reader.read();
+    if (done) {
+      controller.close();
+      return;
+    }
+
+    const chunk = new TextDecoder().decode(value).trim();
+
+    let parsed;
+    try {
+      parsed = JSON.parse(chunk);
+    } catch {
+      // If the line is not a valid JSON we skip it
+      return;
+    }
+
+    const sdkChunk = {
+      id: parsed.id ?? `ollama-stream-${Date.now()}`,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: parsed.model ?? 'ollama',
+      choices: [
+        {
+          delta: {
+            role: 'assistant',
+            content: parsed.content,
+          },
+          index: 0,
+          finish_reason: null,
+        },
+      ],
+    };
+
+    // Push the chunk as a string followed by a newline (used by SDK)
+    controller.enqueue(new TextEncoder().encode(JSON.stringify(sdkChunk) + '\n'));
+  };
+
+  return new ReadableStream({ pull });
+}
+
+/**
+ * Custom fetch used by `createOpenAI()` when you want to talk to
+ * a local Ollama instance instead of the real OpenAI endpoint.
+ */
+export async function customOllamaFetch(
+    input: string | URL | globalThis.Request,
+    init?: RequestInit,
+): Promise<Response> {
+  console.log(`customOllamaFetch: ${input}`)
+  const req =
+    typeof input === 'string' ? new Request(input, init) : new Request(input, init);
+
+  /* ----------------- Chat / Completion ----------------- */
+  if (
+    req.url.endsWith('/v1/chat/completions') ||
+    req.url.endsWith('/v1/completions')
+  ) {
+    const body = req.body ? await req.json() : {};
+
+    const {
+      model,
+      messages,
+      prompt,
+      temperature,
+      stream,
+    } = body as {
+      model?: string;
+      messages?: Array<{ role: string; content: string }>;
+      prompt?: string;
+      temperature?: number;
+      stream?: boolean;
+    };
+
+    const ollamaBody: any = {
+      model,
+      temperature: typeof temperature === 'number' ? temperature : 0.7,
+      stream: !!stream, // `true` will make Ollama stream back
+    };
+
+    // If the SDK passed a “messages” array we flatten it into a prompt
+    if (Array.isArray(messages)) {
+      ollamaBody.prompt = messages
+        .map((m) => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${m.content}`)
+        .join('\n');
+    } else if (prompt) {
+      ollamaBody.prompt = prompt;
+    }
+
+    const ollamaUrl = 'http://127.0.0.1:11434/api/generate';
+    const ollamaRes = await fetch(ollamaUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ollamaBody),
+    });
+
+    // If streaming, we forward the stream straight back.
+    if (ollamaRes.body && ollamaRes.headers.get('content-type')?.includes('json')) {
+      const ollamaJson = await ollamaRes.json();
+
+      return new Response(
+        JSON.stringify({
+          ok: ollamaRes.ok,
+          status: ollamaRes.status,
+          statusText: ollamaRes.statusText,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({
+            id: `ollama-${model}-${Date.now()}`,
+            object: 'chat.completion',
+            created: Math.floor(Date.now() / 1000),
+            model,
+            usage: {
+              prompt_tokens: ollamaJson.prompt?.tokens ?? 0,
+              completion_tokens: ollamaJson.response?.tokens ?? 0,
+            },
+            choices: [
+              {
+                message: { role: 'assistant', content: ollamaJson.response },
+                finish_reason: 'stop',
+                index: 0,
+              },
+            ],
+          }),
+          text: async () =>
+            JSON.stringify({
+              id: `ollama-${model}-${Date.now()}`,
+              object: 'chat.completion',
+              created: Math.floor(Date.now() / 1000),
+              model,
+              usage: {
+                prompt_tokens: ollamaJson.prompt?.tokens ?? 0,
+                completion_tokens: ollamaJson.response?.tokens ?? 0,
+              },
+              choices: [
+                {
+                  message: { role: 'assistant', content: ollamaJson.response },
+                  finish_reason: 'stop',
+                  index: 0,
+                },
+              ],
+            }),
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+
+    // Streaming case: forward the raw stream and re‑wrap it
+    const sdkStream = ollamaStreamToSdkStream(ollamaRes.body!);
+
+    return new Response(sdkStream, {
+      status: 200,
+      headers: { 'content-type': 'text/plain' }, // the SDK expects text chunks
+    });
+  }
+
+  /* ----------------- `/v1/models` ----------------- */
+  if (req.url.endsWith('/v1/models')) {
+    const modelNames = await getInstalledModelsAsync();
+
+    const data = modelNames.map((name) => ({
+      id: name,
+      object: 'model',
+      created: 0,
+      owned_by: 'ollama',
+    }));
+
+    return new Response(JSON.stringify({ object: 'list', data }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  /* ----------------- `/v1/responses` (streaming) ----------------- */
+  if (req.url.endsWith('/v1/responses')) {
+    const body = req.body ? await req.json() : {};
+    console.log(body)
+
+    const {
+      model,
+      input,
+      prompt,
+      temperature,
+      tool_choice,
+      tools,
+    } = body as {
+      model?: string;
+      input?: Array<{ role: string; content: string | Array<{type: string, text: string}> }>;
+      prompt?: string;
+      temperature?: number;
+      tool_choice?: string;
+      tools?: Array<any>;
+    };
+
+    // Build a stream‑enabled request for Ollama
+    const ollamaBody: any = {
+      model: "gpt-oss:20b",   // TODO
+      temperature,
+      tool_choice,
+      tools,
+      stream: true, // tell Ollama to stream
+      messages: input?.map((row) => ({role: row.role, content: typeof row.content == 'string' ? row.content : row.content.map((c) => (c.text)).join("\n")})),
+      prompt,
+    };
+
+    const ollamaUrl = 'http://127.0.0.1:11434/api/chat';
+    const ollamaRes = await fetch(ollamaUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ollamaBody),
+    });
+
+    console.log(`${JSON.stringify(ollamaBody)}`)
+    if (!ollamaRes.ok) {
+    return new Response(ollamaRes.body, {
+        status: ollamaRes.status,
+        headers: ollamaRes.headers,
+    });
+
+    }
+    const sdkStream = ollamaStreamToSdkStream(ollamaRes.body!);
+
+    return new Response(sdkStream, {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+    });
+  }
+
+  /* ----------------- Anything else – just proxy it unchanged ----------------- */
+  return fetch(req);
+}

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -12,7 +12,7 @@ import welcomeStyles from '../Welcome/Welcome.css';
 
 interface ChatInterfaceProps {
     layout: WebviewLayout;
-    vscode: any;
+    vscode: VsCodeApi;
 }
 
 const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
@@ -1444,6 +1444,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                                         selectedModel={selectedModel}
                                         onModelChange={handleModelChange}
                                         disabled={isLoading || showWelcome}
+                                        vscode={vscode}
                                     />
                                 </div>
                             </div>

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -5,6 +5,7 @@ interface ModelSelectorProps {
     selectedModel: string;
     onModelChange: (model: string) => void;
     disabled?: boolean;
+    vscode: VsCodeApi;
 }
 
 interface ModelOption {
@@ -14,54 +15,138 @@ interface ModelOption {
     category: string;
 }
 
-const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelChange, disabled }) => {
+const getStaticModels = (): ModelOption[] => [
+    // Anthropic
+    { id: 'claude-4-opus-20250514', name: 'Claude 4 Opus', provider: 'Anthropic', category: 'Premium' },
+    { id: 'claude-4-sonnet-20250514', name: 'Claude 4 Sonnet', provider: 'Anthropic', category: 'Balanced' },
+    { id: 'claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet', provider: 'Anthropic', category: 'Balanced' },
+    { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', provider: 'Anthropic', category: 'Balanced' },
+    // Google (Direct)
+    { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google', category: 'Balanced' },
+    { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google', category: 'Fast' },
+    { id: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite', provider: 'Google', category: 'Fast' },
+    // Google (OpenRouter)
+    { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'OpenRouter (Google)', category: 'Balanced' },
+    // Meta (OpenRouter)
+    { id: 'meta-llama/llama-4-maverick-17b-128e-instruct', name: 'Llama 4 Maverick 17B', provider: 'OpenRouter (Meta)', category: 'Balanced' },
+    // DeepSeek (OpenRouter)
+    { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
+    // Mistral (OpenRouter)
+    { id: 'mistralai/mistral-small-3.2-24b-instruct-2506', name: 'Mistral Small 3.2 24B', provider: 'OpenRouter (Mistral)', category: 'Balanced' },
+    // xAI (OpenRouter)
+    { id: 'x-ai/grok-3', name: 'Grok 3', provider: 'OpenRouter (xAI)', category: 'Balanced' },
+    // Qwen (OpenRouter)
+    { id: 'qwen/qwen3-235b-a22b-04-28', name: 'Qwen3 235B', provider: 'OpenRouter (Qwen)', category: 'Balanced' },
+    // Perplexity (OpenRouter)
+    { id: 'perplexity/sonar-reasoning-pro', name: 'Sonar Reasoning Pro', provider: 'OpenRouter (Perplexity)', category: 'Balanced' },
+    // Microsoft (OpenRouter)
+    { id: 'microsoft/phi-4-reasoning-plus-04-30', name: 'Phi-4 Reasoning Plus', provider: 'OpenRouter (Microsoft)', category: 'Balanced' },
+    // NVIDIA (OpenRouter)
+    { id: 'nvidia/llama-3.3-nemotron-super-49b-v1', name: 'Llama 3.3 Nemotron Super 49B', provider: 'OpenRouter (NVIDIA)', category: 'Balanced' },
+    // Cohere (OpenRouter)
+    { id: 'cohere/command-a-03-2025', name: 'Command A', provider: 'OpenRouter (Cohere)', category: 'Balanced' },
+    // Amazon (OpenRouter)
+    { id: 'amazon/nova-pro-v1', name: 'Nova Pro', provider: 'OpenRouter (Amazon)', category: 'Balanced' },
+    // Inflection (OpenRouter)
+    { id: 'inflection/inflection-3-productivity', name: 'Inflection 3 Productivity', provider: 'OpenRouter (Inflection)', category: 'Balanced' },
+    // Reka (OpenRouter)
+    { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Balanced' },
+    // Existing OpenAI (direct)
+    { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
+    { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }
+];
+
+const getAllModels = async (vscode: VsCodeApi): Promise<ModelOption[]> => {
+    const staticModels = getStaticModels();
+    console.log('[ModelSelector] Starting to load models, static models count:', staticModels.length);
+    
+    try {
+        console.log('[ModelSelector] Requesting Ollama models from extension...');
+        
+        // Request Ollama models from the extension via message passing
+        const response = await new Promise<string[]>((resolve) => {
+            const messageHandler = (event: MessageEvent) => {
+                console.log('[ModelSelector] Received message from extension:', event.data.type, event.data);
+                if (event.data.type === 'ollamaModelsResponse') {
+                    window.removeEventListener('message', messageHandler);
+                    console.log('[ModelSelector] Ollama models received:', event.data.models);
+                    resolve(event.data.models || []);
+                }
+            };
+            
+            window.addEventListener('message', messageHandler);
+            
+            // Send request to extension for Ollama models
+            console.log('[ModelSelector] Sending getOllamaModels request to extension...');
+            vscode.postMessage({
+                command: 'getOllamaModels'
+            });
+            
+            // TODO:  shorten this or remove
+            // Timeout after 3 seconds
+            setTimeout(() => {
+                console.log('[ModelSelector] Timeout waiting for Ollama models, using empty array');
+                window.removeEventListener('message', messageHandler);
+                resolve([]);
+            }, 3000);
+        });
+        
+        console.log('[ModelSelector] Processing Ollama response:', response);
+        const ollamaModels: ModelOption[] = response.map(name => ({
+            id: name,
+            name: name,
+            provider: 'Ollama',
+            category: 'Local'
+        }));
+        
+        console.log('[ModelSelector] Created Ollama models:', ollamaModels);
+        const allModels = [...staticModels, ...ollamaModels];
+        console.log('[ModelSelector] Final model count - static:', staticModels.length, 'ollama:', ollamaModels.length, 'total:', allModels.length);
+        
+        return allModels;
+    } catch (error) {
+        console.error('[ModelSelector] Failed to load Ollama models:', error);
+        return staticModels;
+    }
+};
+
+const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelChange, disabled, vscode }) => {    
     const [isOpen, setIsOpen] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
     const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0 });
+    const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+    const [models, setModels] = useState<ModelOption[]>([]);
     const triggerRef = useRef<HTMLButtonElement>(null);
     const modalRef = useRef<HTMLDivElement>(null);
 
-    const models: ModelOption[] = [
-        // Anthropic
-        { id: 'claude-4-opus-20250514', name: 'Claude 4 Opus', provider: 'Anthropic', category: 'Premium' },
-        { id: 'claude-4-sonnet-20250514', name: 'Claude 4 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        { id: 'claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        // Google (Direct)
-        { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google', category: 'Balanced' },
-        { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google', category: 'Fast' },
-        { id: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite', provider: 'Google', category: 'Fast' },
-        // Google (OpenRouter)
-        { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'OpenRouter (Google)', category: 'Balanced' },
-        // Meta (OpenRouter)
-        { id: 'meta-llama/llama-4-maverick-17b-128e-instruct', name: 'Llama 4 Maverick 17B', provider: 'OpenRouter (Meta)', category: 'Balanced' },
-        // DeepSeek (OpenRouter)
-        { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
-        // Mistral (OpenRouter)
-        { id: 'mistralai/mistral-small-3.2-24b-instruct-2506', name: 'Mistral Small 3.2 24B', provider: 'OpenRouter (Mistral)', category: 'Balanced' },
-        // xAI (OpenRouter)
-        { id: 'x-ai/grok-3', name: 'Grok 3', provider: 'OpenRouter (xAI)', category: 'Balanced' },
-        // Qwen (OpenRouter)
-        { id: 'qwen/qwen3-235b-a22b-04-28', name: 'Qwen3 235B', provider: 'OpenRouter (Qwen)', category: 'Balanced' },
-        // Perplexity (OpenRouter)
-        { id: 'perplexity/sonar-reasoning-pro', name: 'Sonar Reasoning Pro', provider: 'OpenRouter (Perplexity)', category: 'Balanced' },
-        // Microsoft (OpenRouter)
-        { id: 'microsoft/phi-4-reasoning-plus-04-30', name: 'Phi-4 Reasoning Plus', provider: 'OpenRouter (Microsoft)', category: 'Balanced' },
-        // NVIDIA (OpenRouter)
-        { id: 'nvidia/llama-3.3-nemotron-super-49b-v1', name: 'Llama 3.3 Nemotron Super 49B', provider: 'OpenRouter (NVIDIA)', category: 'Balanced' },
-        // Cohere (OpenRouter)
-        { id: 'cohere/command-a-03-2025', name: 'Command A', provider: 'OpenRouter (Cohere)', category: 'Balanced' },
-        // Amazon (OpenRouter)
-        { id: 'amazon/nova-pro-v1', name: 'Nova Pro', provider: 'OpenRouter (Amazon)', category: 'Balanced' },
-        // Inflection (OpenRouter)
-        { id: 'inflection/inflection-3-productivity', name: 'Inflection 3 Productivity', provider: 'OpenRouter (Inflection)', category: 'Balanced' },
-        // Reka (OpenRouter)
-        { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Balanced' },
-        // Existing OpenAI (direct)
-        { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
-        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }
-    ];
+    console.log("[ModelSelector] mounting")
 
+    useEffect(() => {
+        console.log('[ModelSelector] useEffect triggered, calling getAllModels...');
+        getAllModels(vscode).then((models) => {
+            console.log('[ModelSelector] getAllModels completed, setting models:', models.length);
+            setModels(models);
+        }).catch((error) => {
+            console.error('[ModelSelector] getAllModels failed:', error);
+        });
+    }, []);
+
+    /* ---------- derived data ---------- */
+  // distinct provider list (sorted alphabetically)
+  const allProviders = Array.from(
+    new Set(models.map(m => m.provider))
+  ).sort((a, b) => a.localeCompare(b));
+  
+  // filter providers by search (if searchTerm contains provider name)
+  const filteredProviders = allProviders.filter(p =>
+    p.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  // models belonging to the currently selected provider (or all if none)
+  const providerModels = selectedProvider
+    ? models.filter(m => m.provider === selectedProvider)
+    : [];
+    
     const filteredModels = models.filter(model =>
         model.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
         model.provider.toLowerCase().includes(searchTerm.toLowerCase())
@@ -137,6 +222,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
     const handleModelSelect = (modelId: string) => {
         onModelChange(modelId);
         setIsOpen(false);
+        setSelectedProvider(null);
     };
 
     const handleToggleOpen = () => {
@@ -358,6 +444,49 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
                         align-items: center;
                         justify-content: center;
                     }
+
+                                        .model-selector-inner {
+                        overflow: hidden;
+                        width: 100%;
+                        height: 150px;
+                        position: relative;
+                    }
+
+                    .model-selector-panels {
+                        display: flex;
+                        width: 480px;
+                        height: 100%;
+                        transition: transform 0.3s ease;
+                    }
+
+                    .model-selector-panel {
+                        width: 240px;
+                        height: 100%;
+                        overflow-y: auto;
+                        flex-shrink: 0;
+                        position: relative;
+                    }
+
+                    .model-selector-back {
+                        position: sticky;
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                        background: var(--vscode-dropdown-background);
+                        border: none;
+                        border-bottom: 1px solid var(--vscode-dropdown-border);
+                        color: var(--vscode-foreground);
+                        padding: 8px;
+                        cursor: pointer;
+                        font-size: 11px;
+                        text-align: left;
+                        z-index: 1;
+                    }
+
+                    .model-selector-back:hover {
+                        background: var(--vscode-list-hoverBackground);
+                    }
+
                 `}
             </style>
 
@@ -368,9 +497,6 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
                     onClick={handleToggleOpen}
                     disabled={disabled}
                 >
-                    <div className="selector-icon model-icon">
-                        <BrainIcon />
-                    </div>
                     <span>{selectedModelName}</span>
                     <svg 
                         className={`model-selector-arrow ${isOpen ? 'open' : ''}`}
@@ -389,53 +515,97 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
                     </svg>
                 </button>
 
-                {isOpen && (
-                    <div className="model-selector-modal">
-                        <div 
-                            className="model-selector-content" 
-                            ref={modalRef}
-                            style={{
-                                top: dropdownPosition.top,
-                                left: dropdownPosition.left
-                            }}
-                        >
-                            <div className="model-selector-header">
-                                <input
-                                    type="text"
-                                    className="model-selector-search"
-                                    placeholder="Search models..."
-                                    value={searchTerm}
-                                    onChange={(e) => setSearchTerm(e.target.value)}
-                                    autoFocus
-                                />
-                            </div>
 
-                            <div className="model-selector-list">
-                                {filteredModels.map((model) => (
-                                    <button
-                                        key={model.id}
-                                        className={`model-option ${model.id === selectedModel ? 'selected' : ''}`}
-                                        onClick={() => handleModelSelect(model.id)}
-                                    >
-                                        <div className="model-icon">
-                                            <BrainIcon />
-                                        </div>
-                                        <div className="model-info">
-                                            <div className="model-name">{model.name}</div>
-                                            <div className="model-provider">{model.provider}</div>
-                                        </div>
-                                        {model.id === selectedModel && (
-                                            <div className="model-check">✓</div>
-                                        )}
-                                    </button>
-                                ))}
-                            </div>
+        {isOpen && (
+          <div className="model-selector-modal">
+            <div
+              className="model-selector-content"
+              ref={modalRef}
+              style={{
+                top: dropdownPosition.top,
+                left: dropdownPosition.left,
+              }}
+            >
+              <div className="model-selector-header">
+                <input
+                  type="text"
+                  className="model-selector-search"
+                  placeholder="Search…"
+                  value={searchTerm}
+                  onChange={e => setSearchTerm(e.target.value)}
+                  autoFocus
+                />
+              </div>
+
+              <div className="model-selector-inner">
+                <div
+                  className="model-selector-panels"
+                  style={{
+                    transform:
+                      selectedProvider !== null
+                        ? 'translateX(-240px)'
+                        : 'translateX(0)',
+                  }}
+                >
+                  {/* Provider panel */}
+                  <div className="model-selector-panel">
+                    {filteredProviders.map(provider => (
+                      <button
+                        key={provider}
+                        className="model-option"
+                        onClick={() => {
+                          setSelectedProvider(provider);
+                          setSearchTerm('');
+                        }}
+                      >
+                        <div className="model-icon">
+                          <BrainIcon />
                         </div>
-                    </div>
-                )}
+                        <div className="model-info">
+                          <div className="model-name">{provider}</div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+
+                  {/* 2⃣ Model panel */}
+                <div className="model-selector-panel">
+                  {/* Back button – positioned absolutely inside the panel */}
+                  <button
+                    className="model-selector-back"
+                    onClick={() => {
+                      // Reset the search so the provider list is shown cleanly
+                      setSearchTerm('');
+                      setSelectedProvider(null);
+                    }}
+                  >
+                    ← Back
+                  </button>
+                    {providerModels.map(model => (
+                      <button
+                        key={model.id}
+                        className={`model-option ${model.id === selectedModel ? 'selected' : ''}`}
+                        onClick={() => handleModelSelect(model.id)}
+                      >
+                        <div className="model-icon">
+                          <BrainIcon />
+                        </div>
+                        <div className="model-info">
+                          <div className="model-name">{model.name}</div>
+                          <div className="model-provider">{model.provider}</div>
+                        </div>
+                        {model.id === selectedModel && <div className="model-check">✓</div>}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
-        </>
-    );
+          </div>
+        )}
+      </div>
+    </>
+  );
 };
 
-export default ModelSelector; 
+export default ModelSelector;

--- a/src/webview/types.d.ts
+++ b/src/webview/types.d.ts
@@ -35,11 +35,13 @@ declare module '*.css' {
   }
   
   // VS Code webview API
-  declare function acquireVsCodeApi(): {
+  interface VsCodeApi<T = any> {
     postMessage(message: any): void;
-    getState(): any;
-    setState(state: any): void;
-  };
+    setState(state: T): void;
+    getState(): T | undefined;
+}
+
+declare function acquireVsCodeApi<T = unknown>(): VsCodeApi<T>;
 
 // Add csp property to React's iframe attributes
 declare namespace React {


### PR DESCRIPTION
TODO: make providers properly typed then factor out ollama vs openai provider setup

## Summary by Sourcery

Add support for local Ollama language models by discovering them via CLI, integrating them into the model selector UI, and routing SDK API calls to a local Ollama server through a custom fetch.

New Features:
- Discover and list local Ollama models via the `ollama list` CLI and surface them in the model selector
- Implement `customOllamaFetch` to proxy chat and completion API calls to a local Ollama instance

Enhancements:
- Refactor ModelSelector to asynchronously load static and Ollama models and introduce provider-based two-panel navigation
- Extend ChatSidebarProvider to handle `getOllamaModels` messaging and forward model lists to the webview
- Enhance CustomAgentService with robust error extraction and conditional use of the custom Ollama fetch
- Formalize VS Code webview API types by introducing a generic `VsCodeApi` interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local model support: automatically discovers and lists installed Ollama models alongside cloud providers.
  * Model selection now provider-aware, enabling easier browsing and switching between providers and models.

* **UI/UX**
  * Introduced a two-panel Model Selector with provider list on the left and models on the right, plus a Back control.
  * Enhanced search/filtering within the model list.
  * Visual refinements and clearer provider/model grouping.

* **Improvements**
  * More resilient model loading with graceful fallbacks if local discovery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->