### PR TITLE
Refactor the read tool to better handle truncation

### DIFF
--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -177,11 +177,11 @@ async function processTextFile(
 
     // Only consider content truncated if we hit the limit due to our own constraints,
     // not when the user explicitly requested fewer/zero lines
-    const wasLimitedByDefault = requestedLineCount === undefined && endLine < originalLineCount;
+    const wasLimitedByDefault = requestedLineCount === undefined && selectedLines.length < originalLineCount;
     const wasLimitedByFileSize =
         requestedLineCount !== undefined &&
         requestedLineCount > 0 &&
-        endLine < actualStartLine + requestedLineCount;
+        selectedLines.length < requestedLineCount;
     const contentWasTruncated = wasLimitedByDefault || wasLimitedByFileSize;
     const isTruncated = contentWasTruncated || linesWereTruncated;
 

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -155,7 +155,7 @@ async function processTextFile(
 
     // Handle line range with proper validation and clamping
     const clampedStartLine = Math.max(Math.floor(startLine ?? 1), 1); // Ensure positive integer, 1-based
-    const actualStartLine = Math.max(clampedStartLine - 1, 0); // Convert to 0-based
+    const actualStartLine = clampedStartLine - 1; // Convert to 0-based
 
     // Clamp lineCount to non-negative integer, with special handling for explicit 0
     const requestedLineCount =


### PR DESCRIPTION
  Fixed Issues:

  1. Clamping to valid ranges: startLine and lineCount are now properly clamped to positive integers using Math.max(Math.floor(...), min_value)
  2. Proper truncation detection: The code now distinguishes between:
    - User explicitly requesting 0/few lines (requestedLineCount !== undefined)
    - System limiting due to default constraints (requestedLineCount === undefined)
  3. Conditional truncation headers: The "Content truncated" message only appears when we actually truncated content, not when the user explicitly asked for
  fewer lines
  4. Conditional linesShown: The linesShown metadata is only included when selectedLines.length > 0, preventing confusing ranges like [1, 0]

  Key Improvements:

  - lineCount=0 now returns empty content without truncation headers
  - Negative values are clamped to valid ranges
  - No more misleading "lines 1-0" displays
  - Cleaner UX when users request specific line ranges

## Summary by Sourcery

Refactor text processing in read-tool to validate and clamp line range parameters and accurately report content truncation

Enhancements:
- Clamp and floor startLine and lineCount inputs to ensure valid integer ranges
- Differentiate between default and explicit truncation limits to avoid misleading notices
- Only emit truncation warnings and metadata.linesShown when lines are actually returned