### PR TITLE
Add path validation, tool input normalization, and UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Works seamlessly with Cursor, Windsurf, Claude Code, and plain VS Code.
 
 ---
 
+## Using Claude Code
+
+You can chat using your Claude subscription instead of an API key:
+
+1. Install the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/overview) and log in with `claude login`
+2. Select `Claude Code` under `+ Add Model Provider` — no API key is required
+3. Pick `Claude Sonnet`, `Claude Opus`, or `Claude Haiku` under `Available Models`
+
+If the CLI is not on the extension's PATH you can set the path to the `claude` executable in the provider settings.
+
 ## Using LMStudio
 
 1. In the LMStudio `Developer` pane ensure that `Enable CORS` is turned ON in `⚙️ Settings`

--- a/esbuild.js
+++ b/esbuild.js
@@ -69,6 +69,13 @@ async function main() {
         alias: {
             react: path.resolve(__dirname, './node_modules/react'),
             'react/jsx-runtime': path.resolve(__dirname, './node_modules/react/jsx-runtime.js'),
+            // Prevent the Node-only Claude Code SDK from leaking into the web build
+            '@anthropic-ai/claude-agent-sdk': path.resolve(
+                __dirname,
+                './src/webview/claude-shim.ts'
+            ),
+            '@anthropic-ai/claude-code': path.resolve(__dirname, './src/webview/claude-shim.ts'),
+            'ai-sdk-provider-claude-code': path.resolve(__dirname, './src/webview/claude-shim.ts'),
         },
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ai-sdk/openai-compatible": "^1.0.19",
         "@openrouter/ai-sdk-provider": "^1.2.0",
         "ai": "^5.0.60",
+        "ai-sdk-provider-claude-code": "^2.3.0",
         "ai-sdk-react-model-picker": "^0.4.0",
         "execa": "^9.6.0",
         "glob": "^11.0.3",
@@ -220,6 +221,28 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.77.tgz",
+      "integrity": "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1208,6 +1231,291 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -2175,6 +2483,40 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai-sdk-provider-claude-code": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ai-sdk-provider-claude-code/-/ai-sdk-provider-claude-code-2.3.0.tgz",
+      "integrity": "sha512-iUP1v4DUPITgW3I4hSF3tCVBTv2q9F6CKR96Y1lOYqQUjjeZunv2MqImnCsIBvDdmCLu/Qj8+iVAmNaaN4iqTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.9",
+        "@anthropic-ai/claude-agent-sdk": "^0.1.59"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/ai-sdk-provider-claude-code/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.9.tgz",
+      "integrity": "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
       }
     },
     "node_modules/ai-sdk-react-model-picker": {

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "@ai-sdk/openai-compatible": "^1.0.19",
     "@openrouter/ai-sdk-provider": "^1.2.0",
     "ai": "^5.0.60",
+    "ai-sdk-provider-claude-code": "^2.3.0",
     "ai-sdk-react-model-picker": "^0.4.0",
     "execa": "^9.6.0",
     "glob": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "format": "prettier --write src",
     "format:check": "prettier --check .",
     "lint:fix": "npm run lint -- --fix",
+    "test:chat-utils": "tsc --project tsconfig.test.json && node dist-test/test/chat-utils.test.js",
     "test:llm": "tsc --project tsconfig.test.json && node dist-test/test/llm-service.test.js",
     "test:core": "tsc --project tsconfig.test.json && node dist-test/test/core-components.test.js",
     "test:read": "tsc --project tsconfig.test.json && node dist-test/test/read-tool.test.js",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "format:check": "prettier --check .",
     "lint:fix": "npm run lint -- --fix",
     "test:chat-utils": "tsc --project tsconfig.test.json && node dist-test/test/chat-utils.test.js",
+    "test:tool-utils": "tsc --project tsconfig.test.json && node dist-test/test/tool-utils.test.js",
     "test:llm": "tsc --project tsconfig.test.json && node dist-test/test/llm-service.test.js",
     "test:core": "tsc --project tsconfig.test.json && node dist-test/test/core-components.test.js",
     "test:read": "tsc --project tsconfig.test.json && node dist-test/test/read-tool.test.js",

--- a/src/test/chat-utils.test.ts
+++ b/src/test/chat-utils.test.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import { normalizeToolInput } from '../webview/utils/chatUtils';
+
+function testObjectInputPassesThrough(): void {
+    const raw = { file_path: 'design.html', description: 'Create page' };
+    const { input, display } = normalizeToolInput(raw);
+    assert.deepStrictEqual(input, raw);
+    assert.ok(display.includes('design.html'));
+    console.log('✓ object input passes through');
+}
+
+function testStringInputIsParsed(): void {
+    // DeepSeek and some OpenRouter-routed models deliver input as a JSON string,
+    // which previously crashed rendering with:
+    // "Cannot use 'in' operator to search for 'description'"
+    const raw = JSON.stringify({
+        file_path: 'design_iterations/ui_1.html',
+        create_dirs: true,
+        content: '<html></html>',
+    });
+    const { input, display } = normalizeToolInput(raw);
+    assert.ok(input !== undefined);
+    assert.strictEqual(input.file_path, 'design_iterations/ui_1.html');
+    assert.strictEqual(input.create_dirs, true);
+    assert.ok(display.includes('ui_1.html'));
+    console.log('✓ JSON string input is parsed to an object');
+}
+
+function testMalformedStringInputDoesNotThrow(): void {
+    // Truncated mid-stream payloads must render raw instead of crashing
+    const raw = '{"file_path": "design.html", "content": "<html>';
+    const { input, display } = normalizeToolInput(raw);
+    assert.strictEqual(input, undefined);
+    assert.strictEqual(display, raw);
+    console.log('✓ malformed JSON string renders raw without throwing');
+}
+
+function testNullAndUndefined(): void {
+    assert.deepStrictEqual(normalizeToolInput(undefined), { input: undefined, display: '' });
+    assert.deepStrictEqual(normalizeToolInput(null), { input: undefined, display: '' });
+    console.log('✓ null/undefined input is handled');
+}
+
+function testNonObjectJsonString(): void {
+    const { input, display } = normalizeToolInput('"just a string"');
+    assert.strictEqual(input, undefined);
+    assert.strictEqual(display, '"just a string"');
+    console.log('✓ non-object JSON string renders raw');
+}
+
+function testArrayAndPrimitiveInputs(): void {
+    const arrayResult = normalizeToolInput([1, 2, 3]);
+    assert.strictEqual(arrayResult.input, undefined);
+    const numberResult = normalizeToolInput(42);
+    assert.strictEqual(numberResult.input, undefined);
+    assert.strictEqual(numberResult.display, '42');
+    console.log('✓ array and primitive inputs are handled');
+}
+
+function main(): void {
+    console.log('Running chatUtils.normalizeToolInput tests...');
+    testObjectInputPassesThrough();
+    testStringInputIsParsed();
+    testMalformedStringInputDoesNotThrow();
+    testNullAndUndefined();
+    testNonObjectJsonString();
+    testArrayAndPrimitiveInputs();
+    console.log('All chatUtils tests passed.');
+}
+
+main();

--- a/src/test/tool-utils.test.ts
+++ b/src/test/tool-utils.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { validateWorkspacePath, resolveWorkspacePath } from '../tools/tool-utils';
+import type { ExecutionContext } from '../types/agent';
+
+const WORKSPACE = path.resolve(path.sep, 'home', 'user', 'landpage');
+
+const context = {
+    workingDirectory: WORKSPACE,
+    sessionId: 'test-session',
+    logger: {
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+    },
+} as unknown as ExecutionContext;
+
+function testRelativePathIsAccepted(): void {
+    assert.strictEqual(validateWorkspacePath('design_iterations/ui.html', context), null);
+    assert.strictEqual(
+        resolveWorkspacePath('design_iterations/ui.html', context),
+        path.join(WORKSPACE, 'design_iterations', 'ui.html')
+    );
+    console.log('✓ relative paths resolve inside the workspace');
+}
+
+function testAbsolutePathInsideWorkspaceIsAccepted(): void {
+    const inside = path.join(WORKSPACE, 'theme.css');
+    assert.strictEqual(validateWorkspacePath(inside, context), null);
+    assert.strictEqual(resolveWorkspacePath(inside, context), inside);
+    console.log('✓ absolute paths inside the workspace are accepted');
+}
+
+function testHallucinatedAbsolutePrefixIsRemapped(): void {
+    // Weaker models emit paths like "/path/to/<workspace name>/UI/theme.css"
+    const hallucinated = path.join(path.sep, 'path', 'to', 'landpage', 'UI', 'theme.css');
+    assert.strictEqual(validateWorkspacePath(hallucinated, context), null);
+    assert.strictEqual(
+        resolveWorkspacePath(hallucinated, context),
+        path.join(WORKSPACE, 'UI', 'theme.css')
+    );
+    console.log('✓ hallucinated absolute prefix is remapped into the workspace');
+}
+
+function testForeignAbsolutePathIsRejectedWithGuidance(): void {
+    const foreign = path.join(path.sep, 'etc', 'passwd');
+    const error = validateWorkspacePath(foreign, context);
+    assert.ok(error !== null);
+    assert.strictEqual(error.error_type, 'security');
+    assert.ok(error.error.includes('relative to the workspace root'));
+    console.log('✓ out-of-workspace absolute paths are rejected with corrective guidance');
+}
+
+function testSiblingDirectoryPrefixIsRejected(): void {
+    // "/home/user/landpage-evil" must not pass the "/home/user/landpage" prefix check
+    const sibling = `${WORKSPACE}-evil${path.sep}file.txt`;
+    const error = validateWorkspacePath(sibling, context);
+    assert.ok(error !== null);
+    assert.strictEqual(error.error_type, 'security');
+    console.log('✓ sibling directories sharing a name prefix are rejected');
+}
+
+function testTraversalIsRejected(): void {
+    const error = validateWorkspacePath('../outside.txt', context);
+    assert.ok(error !== null);
+    assert.strictEqual(error.error_type, 'security');
+    console.log('✓ ".." traversal is rejected');
+}
+
+function main(): void {
+    console.log('Running tool-utils workspace path tests...');
+    testRelativePathIsAccepted();
+    testAbsolutePathInsideWorkspaceIsAccepted();
+    testHallucinatedAbsolutePrefixIsRemapped();
+    testForeignAbsolutePathIsRejectedWithGuidance();
+    testSiblingDirectoryPrefixIsRejected();
+    testTraversalIsRejected();
+    console.log('All tool-utils tests passed.');
+}
+
+main();

--- a/src/tools/tool-utils.ts
+++ b/src/tools/tool-utils.ts
@@ -67,6 +67,33 @@ export function handleToolError(
     };
 }
 
+function isWithinDirectory(resolvedPath: string, directory: string): boolean {
+    return resolvedPath === directory || resolvedPath.startsWith(directory + path.sep);
+}
+
+/**
+ * Models (especially smaller local ones) often hallucinate an absolute prefix
+ * for workspace files, e.g. "/path/to/<workspace name>/UI/theme.css". When the
+ * workspace directory name appears as a segment of an out-of-workspace
+ * absolute path, remap the remainder into the workspace. Returns null when no
+ * safe remapping exists.
+ */
+function remapAbsolutePathIntoWorkspace(filePath: string, workspaceDir: string): string | null {
+    const workspaceName = path.basename(workspaceDir);
+    if (workspaceName.length === 0) {
+        return null;
+    }
+
+    const segments = path.normalize(filePath).split(path.sep).filter(Boolean);
+    const workspaceIndex = segments.lastIndexOf(workspaceName);
+    if (workspaceIndex === -1) {
+        return null;
+    }
+
+    const remapped = path.resolve(workspaceDir, ...segments.slice(workspaceIndex + 1));
+    return isWithinDirectory(remapped, workspaceDir) ? remapped : null;
+}
+
 /**
  * Validate if a path is within the workspace directory (supports both absolute and relative paths)
  */
@@ -95,9 +122,13 @@ export function validateWorkspacePath(
         }
 
         // Check if path is within workspace boundary
-        if (!resolvedPath.startsWith(normalizedWorkspace)) {
+        if (!isWithinDirectory(resolvedPath, normalizedWorkspace)) {
+            if (remapAbsolutePathIntoWorkspace(filePath, normalizedWorkspace) !== null) {
+                return null;
+            }
             return handleToolError(
-                `Path must be within workspace directory: ${filePath}`,
+                `Path must be within the workspace directory (${normalizedWorkspace}): ${filePath}. ` +
+                    `Use a path relative to the workspace root instead, e.g. ".superdesign/design_iterations/file.html"`,
                 'Security check',
                 'security'
             );
@@ -110,11 +141,18 @@ export function validateWorkspacePath(
 }
 
 /**
- * Safely resolve a file path (supports both absolute and relative paths)
+ * Safely resolve a file path (supports both absolute and relative paths).
+ * Must stay in sync with validateWorkspacePath so a validated path resolves
+ * to the same location the validation approved.
  */
 export function resolveWorkspacePath(filePath: string, context: ExecutionContext): string {
     if (path.isAbsolute(filePath)) {
-        return path.normalize(filePath);
+        const normalized = path.normalize(filePath);
+        const normalizedWorkspace = path.normalize(context.workingDirectory);
+        if (isWithinDirectory(normalized, normalizedWorkspace)) {
+            return normalized;
+        }
+        return remapAbsolutePathIntoWorkspace(filePath, normalizedWorkspace) ?? normalized;
     } else {
         return path.resolve(context.workingDirectory, filePath);
     }

--- a/src/webview/App.css
+++ b/src/webview/App.css
@@ -923,6 +923,36 @@
     font-family: var(--vscode-editor-font-family);
 }
 
+.empty-state__prompts {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin: 16px 0;
+}
+
+.empty-state__prompt-btn {
+    background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+    color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+    border: 1px solid var(--vscode-button-border, transparent);
+    border-radius: 4px;
+    padding: 6px 14px;
+    font-size: 12px;
+    cursor: pointer;
+    max-width: 320px;
+}
+
+.empty-state__prompt-btn:hover {
+    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
+.empty-state__hint {
+    max-width: 420px;
+    margin: 12px auto 0;
+    font-size: 12px;
+    opacity: 0.85;
+}
+
 /* Design Panel Styles */
 .design-panel {
     flex: 1;

--- a/src/webview/claude-shim.ts
+++ b/src/webview/claude-shim.ts
@@ -1,0 +1,8 @@
+// Browser stand-in for the Node-only Claude Code SDK. The webview only needs
+// provider metadata and configuration; model instances are created in the
+// extension host. Match the shape expected by ai-sdk-provider-claude-code.
+export function createClaudeCode(): never {
+    throw new Error('Claude Code SDK is not available in the browser build.');
+}
+
+export default {};

--- a/src/webview/components/CanvasView.tsx
+++ b/src/webview/components/CanvasView.tsx
@@ -648,15 +648,41 @@ const CanvasView: React.FC<CanvasViewProps> = ({ nonce }) => {
     }
 
     if (designFiles.length === 0) {
+        const samplePrompts = [
+            'Help me design a calculator UI',
+            'Design a modern login screen',
+            'Create a dashboard with a sidebar and stat cards',
+        ];
+        const handleSamplePrompt = (prompt: string) => {
+            const promptMessage: WebviewMessage = {
+                command: 'setChatPrompt',
+                data: { prompt },
+            };
+            vscode.postMessage(promptMessage);
+        };
         return (
             <div className='canvas-empty'>
                 <div className='empty-state'>
-                    <h3>
-                        No design files found in <code>.superdesign/design_iterations/</code>
-                    </h3>
+                    <h3>No designs yet</h3>
                     <p>
-                        Prompt SecureDesign OR Cursor/Windsurf/Claude Code to design UI like{' '}
-                        <kbd>Help me design a calculator UI</kbd> and preview the UI here
+                        Ask SecureDesign to create something in the chat panel, and it will show up
+                        here automatically. Try one of these to get started:
+                    </p>
+                    <div className='empty-state__prompts'>
+                        {samplePrompts.map(prompt => (
+                            <button
+                                key={prompt}
+                                className='empty-state__prompt-btn'
+                                onClick={() => handleSamplePrompt(prompt)}
+                                title='Send this prompt to the chat panel'
+                            >
+                                {prompt}
+                            </button>
+                        ))}
+                    </div>
+                    <p className='empty-state__hint'>
+                        You can also prompt Cursor/Windsurf/Claude Code directly — generated files
+                        in <code>.superdesign/design_iterations/</code> are previewed here.
                     </p>
                 </div>
             </div>

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -19,7 +19,7 @@ import type {
     ToolCallPart,
     ToolResultPart,
 } from '@ai-sdk/provider-utils';
-import { isToolCallPart, isToolResultPart } from '../../utils/chatUtils';
+import { isToolCallPart, isToolResultPart, normalizeToolInput } from '../../utils/chatUtils';
 import {
     createDefaultRegistry,
     type ModelId,
@@ -862,7 +862,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout }) => {
     ) => {
         try {
             const toolName = toolCallPart.toolName ?? 'Unknown Tool';
-            const toolInput = toolCallPart.input as object;
+            const { input: toolInput, display: toolInputDisplay } = normalizeToolInput(
+                toolCallPart.input
+            );
             const uniqueKey = `${messageIndex}_${subIndex}`;
             const { toolCallId } = toolCallPart;
 
@@ -891,12 +893,15 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout }) => {
 
                 // Extract theme data from tool input
                 const themeName =
-                    ('theme_name' in toolInput ? String(toolInput.theme_name) : undefined) ??
-                    'Untitled Theme';
+                    (toolInput !== undefined && 'theme_name' in toolInput
+                        ? String(toolInput.theme_name)
+                        : undefined) ?? 'Untitled Theme';
                 const cssSheet =
-                    ('cssSheet' in toolInput ? toolInput.cssSheet : undefined) ?? undefined;
+                    (toolInput !== undefined && 'cssSheet' in toolInput
+                        ? toolInput.cssSheet
+                        : undefined) ?? undefined;
                 const cssFilePath =
-                    'cssFilePath' in toolInput
+                    toolInput !== undefined && 'cssFilePath' in toolInput
                         ? toolInput.cssFilePath
                         : toolResultPart?.output?.type === 'json' &&
                             'cssFilePath' in (toolResultPart?.output?.value as object)
@@ -971,9 +976,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout }) => {
             const isExpanded = expandedTools[uniqueKey] ?? false;
 
             const description: string =
-                'description' in toolInput ? (toolInput.description as string) : '';
-            const command: string = 'command' in toolInput ? (toolInput.command as string) : '';
-            const prompt: string = 'prompt' in toolInput ? (toolInput.prompt as string) : '';
+                typeof toolInput?.description === 'string' ? toolInput.description : '';
+            const command: string = typeof toolInput?.command === 'string' ? toolInput.command : '';
+            const prompt: string = typeof toolInput?.prompt === 'string' ? toolInput.prompt : '';
 
             const toolComplete = !!toolResultPart;
 
@@ -1011,19 +1016,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout }) => {
                 }));
             };
 
-            // Input truncation with safe handling
-            const inputString: string = (() => {
-                try {
-                    return JSON.stringify(toolInput, null, 2);
-                } catch (error) {
-                    console.error(
-                        '❌ Error: Failed to stringify tool input for tool:',
-                        toolCallPart.toolName,
-                        error
-                    );
-                    return '[Tool input serialization failed]';
-                }
-            })();
+            const hasToolInputDetails =
+                (toolInput !== undefined && Object.keys(toolInput).length > 0) ||
+                toolInputDisplay.trim().length > 0;
 
             return (
                 <div
@@ -1079,11 +1074,13 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout }) => {
                                     <code className='tool-detail__value'>{command}</code>
                                 </div>
                             )}
-                            {Object.keys(toolInput).length > 0 && (
+                            {hasToolInputDetails && (
                                 <div className='tool-detail'>
                                     <span className='tool-detail__label'>Input:</span>
                                     <div className='tool-detail__value tool-detail__value--result'>
-                                        <pre className='tool-result-content'>{inputString}</pre>
+                                        <pre className='tool-result-content'>
+                                            {toolInputDisplay}
+                                        </pre>
                                     </div>
                                 </div>
                             )}

--- a/src/webview/utils/chatUtils.ts
+++ b/src/webview/utils/chatUtils.ts
@@ -15,6 +15,62 @@ export function isToolCallPart(value: unknown): value is ToolCallPart {
     return true;
 }
 
+export interface NormalizedToolInput {
+    /** Parsed key/value input when the payload is (or parses to) a plain object */
+    readonly input: Record<string, unknown> | undefined;
+    /** Human-readable rendering of the payload, regardless of its original shape */
+    readonly display: string;
+}
+
+/**
+ * Some providers (e.g. DeepSeek, or models routed through OpenRouter) deliver
+ * tool-call input as a JSON string rather than a parsed object. Normalize any
+ * payload shape so rendering code can safely use `in` checks and key access.
+ */
+export function normalizeToolInput(rawInput: unknown): NormalizedToolInput {
+    if (rawInput === undefined || rawInput === null) {
+        return { input: undefined, display: '' };
+    }
+
+    if (typeof rawInput === 'string') {
+        try {
+            const parsed: unknown = JSON.parse(rawInput);
+            if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                return {
+                    input: parsed as Record<string, unknown>,
+                    display: JSON.stringify(parsed, null, 2),
+                };
+            }
+        } catch {
+            // Not JSON (or truncated mid-stream) — fall through and show it raw
+        }
+        return { input: undefined, display: rawInput };
+    }
+
+    if (typeof rawInput === 'object') {
+        let display: string;
+        try {
+            display = JSON.stringify(rawInput, null, 2);
+        } catch {
+            display = '[Tool input serialization failed]';
+        }
+        if (Array.isArray(rawInput)) {
+            return { input: undefined, display };
+        }
+        return { input: rawInput as Record<string, unknown>, display };
+    }
+
+    if (
+        typeof rawInput === 'number' ||
+        typeof rawInput === 'boolean' ||
+        typeof rawInput === 'bigint'
+    ) {
+        return { input: undefined, display: String(rawInput) };
+    }
+
+    return { input: undefined, display: '' };
+}
+
 export function isToolResultPart(value: unknown): value is ToolResultPart {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
     if (!Object.prototype.hasOwnProperty.call(value, 'type')) return false;


### PR DESCRIPTION
## Summary

This PR adds robust path validation for workspace security, normalizes tool input handling across different AI provider formats, improves the empty state UX with sample prompts, and adds comprehensive test coverage for these new features.

## Key Changes

### Path Validation & Security (`src/tools/tool-utils.ts`)
- Added `isWithinDirectory()` helper to safely check path containment (prevents sibling directory prefix bypass)
- Implemented `remapAbsolutePathIntoWorkspace()` to handle hallucinated absolute paths from smaller models (e.g., `/path/to/landpage/UI/theme.css` → workspace-relative path)
- Enhanced `validateWorkspacePath()` with improved error messages guiding users to use relative paths
- Updated `resolveWorkspacePath()` to stay in sync with validation logic and apply the same remapping

### Tool Input Normalization (`src/webview/utils/chatUtils.ts`)
- Added `normalizeToolInput()` function to handle tool input delivered as JSON strings by some providers (DeepSeek, OpenRouter-routed models)
- Safely parses JSON strings, validates object shape, and provides both structured input and display representation
- Gracefully handles malformed/truncated payloads without throwing
- Exported `NormalizedToolInput` interface for type safety

### Chat Interface Updates (`src/webview/components/Chat/ChatInterface.tsx`)
- Integrated `normalizeToolInput()` to prevent crashes from string-based tool inputs
- Replaced unsafe `in` operator checks with optional chaining and type guards
- Simplified input serialization by using normalized display output
- Added `hasToolInputDetails` check to properly render tool input sections

### Canvas View UX (`src/webview/components/CanvasView.tsx`)
- Replaced generic empty state with actionable sample prompts
- Added interactive buttons that populate the chat with example prompts
- Improved messaging to guide users on how designs appear automatically
- Better visual hierarchy with hint text about file locations

### Styling (`src/webview/App.css`)
- Added `.empty-state__prompts` flex layout for sample prompt buttons
- Styled `.empty-state__prompt-btn` with VSCode theme variables
- Added `.empty-state__hint` for secondary guidance text

### Build & Documentation
- Added esbuild aliases to prevent Node-only Claude Code SDK from leaking into webview bundle
- Added test scripts (`test:chat-utils`, `test:tool-utils`) to package.json
- Updated README with Claude Code provider setup instructions

## Test Coverage

Added comprehensive test suites:
- **`src/test/tool-utils.test.ts`**: 6 tests covering relative paths, absolute paths, hallucinated prefixes, foreign paths, sibling directory rejection, and traversal prevention
- **`src/test/chat-utils.test.ts`**: 6 tests covering object input, JSON string parsing, malformed input, null/undefined, non-object JSON, and primitive types

## Notable Implementation Details

- Path validation uses normalized path comparison with separator-aware boundary checking to prevent false positives
- Hallucination remapping uses `lastIndexOf()` to find the workspace name segment, allowing recovery even when the full path is fabricated
- Tool input normalization preserves both parsed structure (for safe property access) and display representation (for rendering)
- Empty state prompts use `setChatPrompt` message to integrate seamlessly with existing chat flow

https://claude.ai/code/session_01HhfPeyDkq6rxAh87EC11HR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/secure-design/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

